### PR TITLE
feat(extension): Better extension usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,8 @@ use Storyblok\Tiptap\Extension\Storyblok;
 $editor = new Editor([
     'extensions' => [
         new Storyblok([
-            'extensions' => [
-                'codeBlock' => false,
-                'heading' => false,
+            'override_extensions' => [
+                'codeBlock' => new MyCustomCodeBlock(),
             ]
         ]),
     ],

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ echo $editor->getHTML();
 
 You can disable specific **Tiptap extensions** within Storyblok.
 
-### Example: Disabling `codeBlock` and `heading`
+### Example: Overriding Extensions
 
 ```php
 use Tiptap\Editor;
@@ -103,6 +103,28 @@ echo $editor->getHTML();
 ```
 
 For a complete list of enabled extensions by default, check out [`Storyblok\Tiptap\Extension\Storyblok`](src/Extension/Storyblok.php).
+
+### Example: Disabling Extensions
+
+```php
+use Tiptap\Editor;
+use Storyblok\Tiptap\Extension\Storyblok;
+
+$editor = new Editor([
+    'extensions' => [
+        new Storyblok([
+            'disable_extensions' => [
+                'codeBlock',
+                'heading',
+            ]
+        ]),
+    ],
+]);
+
+$editor->setContent(['type' => 'doc', 'content' => [['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'Hello World']]]]);
+
+echo $editor->getHTML();
+```
 
 ## License
 

--- a/src/Extension/Storyblok.php
+++ b/src/Extension/Storyblok.php
@@ -54,7 +54,14 @@ final class Storyblok extends Extension
     {
         parent::__construct($options);
 
-        $this->options['extensions'] = array_merge($this->addOptions()['extensions'], $options['extensions'] ?? []);
+        if (\array_key_exists('extensions', $options)) {
+            @trigger_error(
+                \sprintf('Passing "extensions" to the Storyblok extension is deprecated and will be removed in a future version. Use "override_extensions" instead.'),
+                \E_USER_DEPRECATED
+            );
+        }
+
+        $this->options['override_extensions'] = array_merge($this->addOptions()['override_extensions'], $options['override_extensions'] ?? []);
         $this->options['blokOptions'] = array_merge($this->addOptions()['blokOptions'], $options['blokOptions'] ?? []);
     }
 
@@ -64,38 +71,7 @@ final class Storyblok extends Extension
     public function addOptions(): array
     {
         return [
-            'extensions' => [
-                'image' => true,
-                'text' => true,
-                'paragraph' => true,
-                'link' => true,
-                'blockquote' => true,
-                'bold' => true,
-                'code' => true,
-                'highlight' => true,
-                'strike' => true,
-                'subscript' => true,
-                'superscript' => true,
-                'textStyle' => true,
-                'italic' => true,
-                'underline' => true,
-                'hardBreak' => true,
-                'document' => true,
-                'horizontalRule' => true,
-                'mention' => true,
-                'taskList' => true,
-                'taskItem' => true,
-                'table' => true,
-                'tableRow' => true,
-                'tableCell' => true,
-                'tableHeader' => true,
-                'bulletList' => true,
-                'orderedList' => true,
-                'listItem' => true,
-                'heading' => true,
-                'codeBlock' => true,
-                'blok' => true,
-            ],
+            'override_extensions' => [],
             'blokOptions' => [
                 'renderer' => null, // The user must provide a renderer function
             ],
@@ -107,39 +83,42 @@ final class Storyblok extends Extension
      */
     public function addExtensions(): array
     {
-        return array_filter([
-            $this->options['extensions']['image'] ? new Image() : null,
-            $this->options['extensions']['text'] ? new Text() : null,
-            $this->options['extensions']['paragraph'] ? new Paragraph() : null,
-            $this->options['extensions']['link'] ? new Link() : null,
-            $this->options['extensions']['blockquote'] ? new Blockquote() : null,
-            $this->options['extensions']['bold'] ? new Bold() : null,
-            $this->options['extensions']['code'] ? new Code() : null,
-            $this->options['extensions']['highlight'] ? new Highlight() : null,
-            $this->options['extensions']['strike'] ? new Strike() : null,
-            $this->options['extensions']['subscript'] ? new Subscript() : null,
-            $this->options['extensions']['superscript'] ? new Superscript() : null,
-            $this->options['extensions']['textStyle'] ? new TextStyle() : null,
-            $this->options['extensions']['italic'] ? new Italic() : null,
-            $this->options['extensions']['underline'] ? new Underline() : null,
-            $this->options['extensions']['document'] ? new Document() : null,
-            $this->options['extensions']['horizontalRule'] ? new HorizontalRule() : null,
-            $this->options['extensions']['mention'] ? new Mention() : null,
-            $this->options['extensions']['taskList'] ? new TaskList() : null,
-            $this->options['extensions']['taskItem'] ? new TaskItem() : null,
-            $this->options['extensions']['hardBreak'] ? new HardBreak() : null,
-            $this->options['extensions']['table'] ? new Table() : null,
-            $this->options['extensions']['tableRow'] ? new TableRow() : null,
-            $this->options['extensions']['tableCell'] ? new TableCell() : null,
-            $this->options['extensions']['tableHeader'] ? new TableHeader() : null,
-            $this->options['extensions']['bulletList'] ? new BulletList() : null,
-            $this->options['extensions']['orderedList'] ? new OrderedList() : null,
-            $this->options['extensions']['listItem'] ? new ListItem() : null,
-            $this->options['extensions']['heading'] ? new Heading() : null,
-            $this->options['extensions']['codeBlock'] ? new CodeBlock() : null,
-            $this->options['extensions']['blok'] ? new Blok([
-                'renderer' => $this->options['blokOptions']['renderer'],
-            ]) : null,
-        ]);
+        return \array_merge(
+            [
+                Image::$name => new Image(),
+                Text::$name => new Text(),
+                Paragraph::$name => new Paragraph(),
+                Link::$name => new Link(),
+                Blockquote::$name => new Blockquote(),
+                Bold::$name => new Bold(),
+                Code::$name => new Code(),
+                Highlight::$name => new Highlight(),
+                Strike::$name => new Strike(),
+                Subscript::$name => new Subscript(),
+                Superscript::$name => new Superscript(),
+                TextStyle::$name => new TextStyle(),
+                Italic::$name => new Italic(),
+                Underline::$name => new Underline(),
+                Document::$name => new Document(),
+                HorizontalRule::$name => new HorizontalRule(),
+                Mention::$name => new Mention(),
+                TaskList::$name => new TaskList(),
+                TaskItem::$name => new TaskItem(),
+                HardBreak::$name => new HardBreak(),
+                Table::$name => new Table(),
+                TableRow::$name => new TableRow(),
+                TableCell::$name => new TableCell(),
+                TableHeader::$name => new TableHeader(),
+                BulletList::$name => new BulletList(),
+                OrderedList::$name => new OrderedList(),
+                ListItem::$name => new ListItem(),
+                Heading::$name => new Heading(),
+                CodeBlock::$name => new CodeBlock(),
+                Blok::$name => new Blok([
+                    'renderer' => $this->options['blokOptions']['renderer']
+                ]),
+            ],
+            $this->options['extensions'],
+        );
     }
 }

--- a/src/Extension/Storyblok.php
+++ b/src/Extension/Storyblok.php
@@ -20,7 +20,6 @@ use Storyblok\Tiptap\Node\Heading;
 use Storyblok\Tiptap\Node\ListItem;
 use Storyblok\Tiptap\Node\OrderedList;
 use Tiptap\Core\Extension;
-use Tiptap\Core\Node;
 use Tiptap\Marks\Bold;
 use Tiptap\Marks\Code;
 use Tiptap\Marks\Highlight;
@@ -57,8 +56,8 @@ final class Storyblok extends Extension
 
         if (\array_key_exists('extensions', $options)) {
             @trigger_error(
-                \sprintf('Passing "extensions" to the Storyblok extension is deprecated and will be removed in a future version. Use "override_extensions" instead.'),
-                \E_USER_DEPRECATED
+                'Passing "extensions" to the Storyblok extension is deprecated and will be removed in a future version. Use "override_extensions" instead.',
+                \E_USER_DEPRECATED,
             );
 
             $this->options['extensions'] = array_merge($this->addOptions()['extensions'], $options['extensions'] ?? []);
@@ -121,11 +120,11 @@ final class Storyblok extends Extension
                 Heading::$name => new Heading(),
                 CodeBlock::$name => new CodeBlock(),
                 Blok::$name => new Blok([
-                    'renderer' => $this->options['blokOptions']['renderer']
+                    'renderer' => $this->options['blokOptions']['renderer'],
                 ]),
             ],
             $this->options['override_extensions'],
-            ...\array_map(static fn(Extension $extension) => [$extension::$name => $extension], \array_filter($this->options['extensions'])),
-        ), fn(string $name) => !\in_array($name, $this->options['disable_extensions']), \ARRAY_FILTER_USE_KEY);
+            ...\array_map(static fn (Extension $extension) => [$extension::$name => $extension], \array_filter($this->options['extensions'])),
+        ), fn (string $name) => !\in_array($name, $this->options['disable_extensions'], true), \ARRAY_FILTER_USE_KEY);
     }
 }

--- a/src/Extension/Storyblok.php
+++ b/src/Extension/Storyblok.php
@@ -65,6 +65,7 @@ final class Storyblok extends Extension
         }
 
         $this->options['override_extensions'] = array_merge($this->addOptions()['override_extensions'], $options['override_extensions'] ?? []);
+        $this->options['disable_extensions'] = array_merge($this->addOptions()['disable_extensions'], $options['disable_extensions'] ?? []);
         $this->options['blokOptions'] = array_merge($this->addOptions()['blokOptions'], $options['blokOptions'] ?? []);
     }
 
@@ -75,6 +76,7 @@ final class Storyblok extends Extension
     {
         return [
             'override_extensions' => [],
+            'disable_extensions' => [],
             'extensions' => [],
             'blokOptions' => [
                 'renderer' => null, // The user must provide a renderer function
@@ -87,7 +89,7 @@ final class Storyblok extends Extension
      */
     public function addExtensions(): array
     {
-        return \array_merge(
+        return \array_filter(\array_merge(
             [
                 Image::$name => new Image(),
                 Text::$name => new Text(),
@@ -123,7 +125,7 @@ final class Storyblok extends Extension
                 ]),
             ],
             $this->options['override_extensions'],
-            ...\array_map(static fn(Node $node) => [$node::$name => $node], \array_filter($this->options['extensions'])),
-        );
+            ...\array_map(static fn(Extension $extension) => [$extension::$name => $extension], \array_filter($this->options['extensions'])),
+        ), fn(string $name) => !\in_array($name, $this->options['disable_extensions']), \ARRAY_FILTER_USE_KEY);
     }
 }

--- a/src/Extension/Storyblok.php
+++ b/src/Extension/Storyblok.php
@@ -20,6 +20,7 @@ use Storyblok\Tiptap\Node\Heading;
 use Storyblok\Tiptap\Node\ListItem;
 use Storyblok\Tiptap\Node\OrderedList;
 use Tiptap\Core\Extension;
+use Tiptap\Core\Node;
 use Tiptap\Marks\Bold;
 use Tiptap\Marks\Code;
 use Tiptap\Marks\Highlight;
@@ -59,6 +60,8 @@ final class Storyblok extends Extension
                 \sprintf('Passing "extensions" to the Storyblok extension is deprecated and will be removed in a future version. Use "override_extensions" instead.'),
                 \E_USER_DEPRECATED
             );
+
+            $this->options['extensions'] = array_merge($this->addOptions()['extensions'], $options['extensions'] ?? []);
         }
 
         $this->options['override_extensions'] = array_merge($this->addOptions()['override_extensions'], $options['override_extensions'] ?? []);
@@ -72,6 +75,7 @@ final class Storyblok extends Extension
     {
         return [
             'override_extensions' => [],
+            'extensions' => [],
             'blokOptions' => [
                 'renderer' => null, // The user must provide a renderer function
             ],
@@ -118,7 +122,8 @@ final class Storyblok extends Extension
                     'renderer' => $this->options['blokOptions']['renderer']
                 ]),
             ],
-            $this->options['extensions'],
+            $this->options['override_extensions'],
+            ...\array_map(static fn(Node $node) => [$node::$name => $node], \array_filter($this->options['extensions'])),
         );
     }
 }

--- a/tests/Unit/Extension/StoryblokTest.php
+++ b/tests/Unit/Extension/StoryblokTest.php
@@ -55,6 +55,7 @@ final class StoryblokTest extends TestCase
     {
         self::assertSame([
             'override_extensions' => [],
+            'disable_extensions' => [],
             'extensions' => [],
             'blokOptions' => [
                 'renderer' => null, // The user must provide a renderer function
@@ -69,11 +70,27 @@ final class StoryblokTest extends TestCase
     {
         $extension = new Storyblok([
             'extensions' => [
-                'image' => false,
+                Image::$name => false,
             ],
         ]);
 
         self::assertArrayNotHasKey('image', $extension->options);
+    }
+
+    /**
+     * @test
+     */
+    public function disableExtensions(): void
+    {
+        $extension = new Storyblok([
+            'disable_extensions' => [
+                Image::$name,
+                Blok::$name,
+            ],
+        ]);
+
+        self::assertArrayNotHasKey('image', $extension->options);
+        self::assertArrayNotHasKey('blok', $extension->options);
     }
 
     /**

--- a/tests/Unit/Extension/StoryblokTest.php
+++ b/tests/Unit/Extension/StoryblokTest.php
@@ -101,7 +101,7 @@ final class StoryblokTest extends TestCase
         $extension = new Storyblok([
             'override_extensions' => [
                 'image' => $object = new Image(),
-            ]
+            ],
         ]);
 
         self::assertSame($object, $extension->addExtensions()['image']);

--- a/tests/Unit/Extension/StoryblokTest.php
+++ b/tests/Unit/Extension/StoryblokTest.php
@@ -53,46 +53,41 @@ final class StoryblokTest extends TestCase
      */
     public function addOptions(): void
     {
-        self::assertSame(
-            [
-                'extensions' => [
-                    'image' => true,
-                    'text' => true,
-                    'paragraph' => true,
-                    'link' => true,
-                    'blockquote' => true,
-                    'bold' => true,
-                    'code' => true,
-                    'highlight' => true,
-                    'strike' => true,
-                    'subscript' => true,
-                    'superscript' => true,
-                    'textStyle' => true,
-                    'italic' => true,
-                    'underline' => true,
-                    'hardBreak' => true,
-                    'document' => true,
-                    'horizontalRule' => true,
-                    'mention' => true,
-                    'taskList' => true,
-                    'taskItem' => true,
-                    'table' => true,
-                    'tableRow' => true,
-                    'tableCell' => true,
-                    'tableHeader' => true,
-                    'bulletList' => true,
-                    'orderedList' => true,
-                    'listItem' => true,
-                    'heading' => true,
-                    'codeBlock' => true,
-                    'blok' => true,
-                ],
-                'blokOptions' => [
-                    'renderer' => null, // The user must provide a renderer function
-                ],
+        self::assertSame([
+            'override_extensions' => [],
+            'extensions' => [],
+            'blokOptions' => [
+                'renderer' => null, // The user must provide a renderer function
             ],
-            (new Storyblok())->addOptions(),
-        );
+        ], (new Storyblok())->addOptions());
+    }
+
+    /**
+     * @test
+     */
+    public function usingDeprecatedExtensionsKey(): void
+    {
+        $extension = new Storyblok([
+            'extensions' => [
+                'image' => false,
+            ],
+        ]);
+
+        self::assertArrayNotHasKey('image', $extension->options);
+    }
+
+    /**
+     * @test
+     */
+    public function usingOverrideExtensions(): void
+    {
+        $extension = new Storyblok([
+            'override_extensions' => [
+                'image' => $object = new Image(),
+            ]
+        ]);
+
+        self::assertSame($object, $extension->addExtensions()['image']);
     }
 
     /**
@@ -102,36 +97,36 @@ final class StoryblokTest extends TestCase
     {
         self::assertEquals(
             [
-                new Image(),
-                new Text(),
-                new Paragraph(),
-                new Link(),
-                new Blockquote(),
-                new Bold(),
-                new Code(),
-                new Highlight(),
-                new Strike(),
-                new Subscript(),
-                new Superscript(),
-                new TextStyle(),
-                new Italic(),
-                new Underline(),
-                new Document(),
-                new HorizontalRule(),
-                new Mention(),
-                new TaskList(),
-                new TaskItem(),
-                new HardBreak(),
-                new Table(),
-                new TableRow(),
-                new TableCell(),
-                new TableHeader(),
-                new BulletList(),
-                new OrderedList(),
-                new ListItem(),
-                new Heading(),
-                new CodeBlock(),
-                new Blok(),
+                Image::$name => new Image(),
+                Text::$name => new Text(),
+                Paragraph::$name => new Paragraph(),
+                Link::$name => new Link(),
+                Blockquote::$name => new Blockquote(),
+                Bold::$name => new Bold(),
+                Code::$name => new Code(),
+                Highlight::$name => new Highlight(),
+                Strike::$name => new Strike(),
+                Subscript::$name => new Subscript(),
+                Superscript::$name => new Superscript(),
+                TextStyle::$name => new TextStyle(),
+                Italic::$name => new Italic(),
+                Underline::$name => new Underline(),
+                Document::$name => new Document(),
+                HorizontalRule::$name => new HorizontalRule(),
+                Mention::$name => new Mention(),
+                TaskList::$name => new TaskList(),
+                TaskItem::$name => new TaskItem(),
+                HardBreak::$name => new HardBreak(),
+                Table::$name => new Table(),
+                TableRow::$name => new TableRow(),
+                TableCell::$name => new TableCell(),
+                TableHeader::$name => new TableHeader(),
+                BulletList::$name => new BulletList(),
+                OrderedList::$name => new OrderedList(),
+                ListItem::$name => new ListItem(),
+                Heading::$name => new Heading(),
+                CodeBlock::$name => new CodeBlock(),
+                Blok::$name => new Blok(),
             ],
             (new Storyblok())->addExtensions(),
         );


### PR DESCRIPTION
Before we had to disable the extensions and then add our overriden ones

```php
$editor = new Editor([
    'extensions' => [
        new Storyblok([
            'blokOptions' => [
                'renderer' => static fn () => /* ... */
            ],
            'extensions' => [
                'heading' => false,
                'link' => false,
            ],
        ]),
        'heading' => new Heading(),
        'emoji' => new Emoji(),
        'link' => new Link(),
    ],
]);
```


Instead of that now we can directly override them:

```php
$editor = new Editor([
    'extensions' => [
        new Storyblok([
            'blokOptions' => [
                'renderer' => static fn () => /* ... */
            ],
            'override_extensions' => [
                Heading::$name => new Heading(),
                Emoji::$name => new Emoji(),
                Link::$name => new Link(),
            ],
            'disable_extensions' => [
                Blok::$name,
            ],
        ]),
    ],
]);
```

