### PR TITLE
Lower minimum PHP requirement to 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=8.3",
+        "php": ">=8.2",
         "thecodingmachine/safe": "^2.0 || ^3.0",
         "ueberdosis/tiptap-php": "^1.4"
     },


### PR DESCRIPTION
This change simply lowers the minimum PHP version to 8.2 in composer.json, which expands compatibility.

There are no dependencies in the package that require PHP 8.3, and no PHP 8.3-specific features are used, so this change does not affect functionality or compatibility with the current codebase.